### PR TITLE
Allow logging in with a social account even if the account wasn't created that way

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -17,8 +17,8 @@ GoogleApi:
   AppID: foo_app
   AppSecret: foo_secret
 SessionValidatorWithSocial:
-  token_name: Token
-  auth_service_name: AuthService
-  email_name: Email
-  user_id_name: UserID
-  password_name: Password
+  token_name: token
+  auth_service_name: authService
+  email_name: email
+  user_id_name: userID
+  password_name: password

--- a/code/authenticators/SocialMemberAuthenticator.php
+++ b/code/authenticators/SocialMemberAuthenticator.php
@@ -20,11 +20,23 @@ class SocialMemberAuthenticator extends MemberAuthenticator {
      * @return bool
      */
     public static function validate_token($token, $service, $userID) {
-        $serviceMap = self::config()->social_services ?: [];
-        if (empty($service) || empty($serviceMap[$service])) return false;
-        /** @var ISocialApi $serviceApi */
-        $serviceApi = Injector::inst()->get($serviceMap[$service]);
+        $serviceApi = self::get_service_api($service);
+        if(!$serviceApi) {
+            return false;
+        }
         return $serviceApi->validateToken($token, $userID);
+    }
+
+    /**
+     * @param string $service
+     * @return bool|ISocialApi
+     */
+    public static function get_service_api($service) {
+        $serviceMap = self::config()->social_services ?: [];
+        if (empty($service) || empty($serviceMap[$service])) {
+            return false;
+        }
+        return Injector::inst()->get($serviceMap[$service]);
     }
 
     /**

--- a/code/authenticators/SocialMemberAuthenticator.php
+++ b/code/authenticators/SocialMemberAuthenticator.php
@@ -15,6 +15,13 @@ class SocialMemberAuthenticator extends MemberAuthenticator {
     ];
 
     /**
+     * @var bool - if this is false, the account must be registered with a social identity to use it for authentication
+     *             if this is true, the social account can authenticate the user as long as the email matches and a new
+     *             SocialIdentity will be attached to the member.
+     */
+    private static $allow_login_to_connect = true;
+
+    /**
      * @param string $token the oauth token for the specified service
      * @param string $service the name of the service (eg. `facebook` or `google`)
      * @param string $userID the id of the user in the service
@@ -26,6 +33,19 @@ class SocialMemberAuthenticator extends MemberAuthenticator {
             return false;
         }
         return $serviceApi->validateToken($token, $userID);
+    }
+
+    /**
+     * @param string $token the oauth token for the specified service
+     * @param string $service the name of the service (eg. `facebook` or `google`)
+     * @return array
+     */
+    public static function get_profile($token, $service) {
+        $serviceApi = self::get_service_api($service);
+        if(!$serviceApi) {
+            return null;
+        }
+        return $serviceApi->getProfileData($token);
     }
 
     /**
@@ -61,11 +81,25 @@ class SocialMemberAuthenticator extends MemberAuthenticator {
                     'AuthService' => $data['AuthService'],
                     'UserID' => $data['UserID']
                 ])->first();
+
                 if ($identity) {
                     $member = $identity->Member();
                     $success = true;
                     return $member;
+                } elseif (self::config()->allow_login_to_connect) {
+                    $profile = self::get_profile($data['Token'], $data['AuthService']);
+                    $member = Member::get()->filter('Email', $profile['Email'])->first();
+                    if ($member && !empty($profile['Email'])) {
+                        $identity = new SocialIdentity();
+                        $identity->MemberID = $member->ID;
+                        $identity->AuthService = $data['AuthService'];
+                        $identity->UserID = $data['UserID'];
+                        $identity->write();
+                        $success = true;
+                        return $member;
+                    }
                 }
+
                 throw new RestUserException("User not found", 401, 401);
             } else {
                 throw new RestUserException("Invalid access token", 401, 401);

--- a/code/connectors/FacebookApi.php
+++ b/code/connectors/FacebookApi.php
@@ -34,4 +34,44 @@ class FacebookApi extends Object implements ISocialApi {
         $user = $response->getGraphUser();
         return $user->getId() == $userID;
     }
+
+    /**
+     * @param string $token
+     * @return array
+     */
+    public function getProfileData($token) {
+        $fb = new Facebook\Facebook([
+            'app_id' => Config::inst()->get('FacebookApi', 'AppID'),
+            'app_secret' => Config::inst()->get('FacebookApi', 'AppSecret'),
+            'default_graph_version' => 'v2.2',
+        ]);
+        try {
+            // Returns a `Facebook\FacebookResponse` object
+            $fieldList = [
+                'id', 'first_name', 'last_name', 'location', 'hometown', 'gender', 'email', 'birthday', 'about',
+                'website'
+            ];
+            $profileResponse = $fb->get('/me?fields='.implode(',', $fieldList), $token);
+            $imageResponse = $fb->get('/me/picture?width=1000&redirect=false', $token);
+        } catch(Facebook\Exceptions\FacebookResponseException $e) {
+            SS_Log::log("Graph returned an error: " . $e->getMessage(), SS_Log::INFO);
+            return false;
+        } catch(Facebook\Exceptions\FacebookSDKException $e) {
+            SS_Log::log('Facebook SDK returned an error: ' . $e->getMessage(), SS_Log::WARN);
+            return false;
+        }
+        $user = $profileResponse->getGraphUser();
+        $imageData = $imageResponse->getGraphNode();
+        $userData = [
+            'FirstName' => $user->getFirstName(),
+            'Surname' => $user->getLastName(),
+            'Email' => $user->getEmail(),
+            'Alias' => $user->getFirstName(),
+            'BirthYear' => $user->getBirthday()->format("Y"),
+            'Description' => $user->getField('about'),
+            'Gender' => $user->getGender(),
+            'ProfileImage' => $imageData->getField('url', null)
+        ];
+        return $userData;
+    }
 }

--- a/code/connectors/GoogleApi.php
+++ b/code/connectors/GoogleApi.php
@@ -45,12 +45,49 @@ class GoogleApi implements ISocialApi {
         }
     }
 
+
     /**
      * @param string $token
      * @return array
+     * @throws RestSystemException
+     * @throws RestUserException
      */
-    public function getProfileData($token)
-    {
-        // TODO: Implement getProfileData() method.
+    public function getProfileData($token) {
+        set_error_handler(
+            create_function('$severity, $message', 'throw new ErrorException($message);')
+        );
+        $client = new Google_Client();
+        $client->setClientId(Config::inst()->get('GoogleApi', 'AppID'));
+        $client->setClientSecret(Config::inst()->get('GoogleApi', 'AppSecret'));
+        $client->addScope(Google_Service_PlusDomains::PLUS_ME);
+        $client->setAccessToken(['access_token' => $token, 'expires_in' => 3600]);
+        $service = new Google_Service_Plus($client);
+        try {
+            $result = $service->people->get('me');
+            restore_error_handler();
+            if ($result) {
+                $emails = $result->getEmails();
+                $userData = [
+                    'FirstName' => $result->getName()->getGivenName(),
+                    'Surname' => $result->getName()->getFamilyName(),
+                    'Email' => !empty($emails) ? $emails[0]->getValue() : '',
+                    'Emails' => array_map(function($email){ return $email->getValue(); }, $emails),
+                    'Alias' => $result->getNickname(),
+                    'BirthYear' => substr($result->getBirthday(), 0, 4),
+                    'Description' => $result->getAboutMe(),
+                    'Gender' => $result->getGender(),
+                    'ProfileImage' => $result->getImage()->getUrl(),
+                ];
+                Debug::log("userdata:".print_r($userData,true));
+                return $userData;
+            }
+            return false;
+        } catch (Google_Service_Exception $e) {
+            restore_error_handler();
+            throw new RestUserException($e->getMessage(), $e->getCode(), 401);
+        } catch(Exception $e) {
+            restore_error_handler();
+            throw new RestSystemException($e->getMessage(), $e->getCode());
+        }
     }
 }

--- a/code/connectors/GoogleApi.php
+++ b/code/connectors/GoogleApi.php
@@ -44,4 +44,13 @@ class GoogleApi implements ISocialApi {
             throw new RestSystemException($e->getMessage(), $e->getCode());
         }
     }
+
+    /**
+     * @param string $token
+     * @return array
+     */
+    public function getProfileData($token)
+    {
+        // TODO: Implement getProfileData() method.
+    }
 }

--- a/code/connectors/ISocialApi.php
+++ b/code/connectors/ISocialApi.php
@@ -19,7 +19,7 @@ interface ISocialApi {
      *
      * @param string $token
      * @param string $userID
-     * @return boolean
+     * @return false
      */
     public function validateToken($token, $userID);
 

--- a/code/connectors/ISocialApi.php
+++ b/code/connectors/ISocialApi.php
@@ -21,4 +21,10 @@ interface ISocialApi {
      * @return boolean
      */
     public function validateToken($token, $userID);
+
+    /**
+     * @param string $token
+     * @return array
+     */
+    public function getProfileData($token);
 }

--- a/tests/functional/FacebookSocialSessionEndpointTest.php
+++ b/tests/functional/FacebookSocialSessionEndpointTest.php
@@ -18,6 +18,9 @@ class FacebookSocialSessionEndpointTest extends RestTest {
         Config::inst()->update('Director', 'rules', [
             'v/1/test-session/$ID/$OtherID' => 'SessionController',
         ]);
+        Config::inst()->update('SessionValidatorWithSocial', 'token_name', 'token');
+        Config::inst()->update('SessionValidatorWithSocial', 'auth_service_name', 'authService');
+        Config::inst()->update('SessionValidatorWithSocial', 'user_id_name', 'userID');
     }
 
     public function testCreateSession() {

--- a/tests/functional/FacebookSocialSessionEndpointTest.php
+++ b/tests/functional/FacebookSocialSessionEndpointTest.php
@@ -23,9 +23,9 @@ class FacebookSocialSessionEndpointTest extends RestTest {
         $this->createUser();
         $this->mockFacebook();
         $data = [
-            'Token' => 'foo_token',
-            'AuthService' => 'facebook',
-            'UserID' => 'foo_user'
+            'token' => 'foo_token',
+            'authService' => 'facebook',
+            'userID' => 'foo_user'
         ];
         $result = $this->makeApiRequest('test-session', ['body' => json_encode($data), 'method' => 'POST']);
         $this->assertTrue(array_key_exists('session', $result));
@@ -36,8 +36,8 @@ class FacebookSocialSessionEndpointTest extends RestTest {
         $this->createUser();
         $this->mockFacebook();
         $data = [
-            'AuthService' => 'facebook',
-            'UserID' => 'foo_user'
+            'authService' => 'facebook',
+            'userID' => 'foo_user'
         ];
         $result = $this->makeApiRequest('test-session', ['body' => json_encode($data), 'method' => 'POST', 'code' => 422]);
         $this->assertTrue(array_key_exists('code', $result));
@@ -48,8 +48,8 @@ class FacebookSocialSessionEndpointTest extends RestTest {
         $this->createUser();
         $this->mockFacebook();
         $data = [
-            'Token' => 'foo_token',
-            'AuthService' => 'facebook'
+            'token' => 'foo_token',
+            'authService' => 'facebook'
         ];
         $result = $this->makeApiRequest('test-session', ['body' => json_encode($data), 'method' => 'POST', 'code' => 422]);
         $this->assertTrue(array_key_exists('code', $result));
@@ -60,9 +60,9 @@ class FacebookSocialSessionEndpointTest extends RestTest {
         $this->createUser();
         $this->mockFacebook();
         $data = [
-            'Token' => 'foo_token',
-            'AuthService' => 'facebook',
-            'UserID' => 'bar_user'
+            'token' => 'foo_token',
+            'authService' => 'facebook',
+            'userID' => 'bar_user'
         ];
         $result = $this->makeApiRequest('test-session', ['body' => json_encode($data), 'method' => 'POST', 'code' => 401]);
         $this->assertTrue(array_key_exists('code', $result));
@@ -73,9 +73,9 @@ class FacebookSocialSessionEndpointTest extends RestTest {
         $this->createUser();
         $this->mockFacebook();
         $data = [
-            'Token' => 'bar_token',
-            'AuthService' => 'facebook',
-            'UserID' => 'foo_user'
+            'token' => 'bar_token',
+            'authService' => 'facebook',
+            'userID' => 'foo_user'
         ];
         $result = $this->makeApiRequest('test-session', ['body' => json_encode($data), 'method' => 'POST', 'code' => 401]);
         $this->assertTrue(array_key_exists('code', $result));

--- a/tests/functional/GoogleSocialSessionEndpointTest.php
+++ b/tests/functional/GoogleSocialSessionEndpointTest.php
@@ -17,6 +17,9 @@ class GoogleSocialSessionEndpointTest extends RestTest {
         Config::inst()->update('Director', 'rules', [
             'v/1/test-session/$ID/$OtherID' => 'SessionController',
         ]);
+        Config::inst()->update('SessionValidatorWithSocial', 'token_name', 'token');
+        Config::inst()->update('SessionValidatorWithSocial', 'auth_service_name', 'authService');
+        Config::inst()->update('SessionValidatorWithSocial', 'user_id_name', 'userID');
     }
 
     public function tearDown() {

--- a/tests/unittests/authenticators/SocialMemberAuthenticatorTest.php
+++ b/tests/unittests/authenticators/SocialMemberAuthenticatorTest.php
@@ -5,9 +5,147 @@
  * @author Christian Blank <c.blank@notthatbad.net>
  */
 class SocialMemberAuthenticatorTest extends SapphireTest {
+    protected $usesDatabase = true;
+
+    /** @var PHPUnit_Framework_MockObject_MockObject */
+    protected $mockFacebook;
+
+    /** @var Member */
+    protected $member;
+
+    /** @var SocialIdentity */
+    protected $identity;
+
+    /** @var SocialMemberAuthenticator */
+    protected $sut;
+
+
+    public function setUp() {
+        parent::setUp();
+
+        $this->mockFacebook = $this->getMock('FacebookApi');
+        Injector::inst()->registerService($this->mockFacebook, 'FacebookApi');
+
+        $this->member = $this->getFixtureFactory()->createObject(
+            'Member',
+            'm1',
+            ['Email' => 'test@test.com', 'Password' => 'tEst1234']
+        );
+        $this->identity = $this->getFixtureFactory()->createObject(
+            'Ntb\SocialIdentity',
+            'i1',
+            [
+                'AuthService' => 'facebook',
+                'UserID'      => 'fb1234',
+                'Member'      => '=>Member.m1',
+            ]
+        );
+        $this->sut = new SocialMemberAuthenticator();
+    }
+
+    /**
+     * Allows us to stub the facebook API's response about whether the access token matches
+     * @param boolean $result
+     */
+    protected function givenFacebookValidatesTheTokenAs($result) {
+        $this->mockFacebook
+            ->expects($this->any())
+            ->method('validateToken')
+            ->will($this->returnValue($result));
+    }
+
+    /**
+     * Allows us to stub the facebook API's response about the profile
+     * @param array $data
+     */
+    protected function givenFacebookReturnsProfileData($data) {
+        $data = array_merge([
+            'FirstName' => 'Test',
+            'Surname' => 'Person',
+            'Email' => 'test@test.com',
+            'Alias' => 'Tester',
+            'BirthYear' => '1980',
+            'Description' => 'this is just for testing',
+            'Gender' => 'M',
+            'ProfileImage' => 'https://placeholdit.imgix.net/~text?txtsize=33&txt=Obnoxious+Selfie&w=350&h=350'
+        ], $data);
+        $this->mockFacebook
+            ->expects($this->any())
+            ->method('getProfileData')
+            ->will($this->returnValue($data));
+    }
 
     public function testValidateTokenWithWrongSocialAdapter() {
         $this->assertFalse(SocialMemberAuthenticator::validate_token('randomToken1234', 'notSupported', 'user'));
     }
 
+    public function testCanAuthenticateWithValidToken() {
+        $this->givenFacebookValidatesTheTokenAs(true);
+        $member = $this->sut->authenticate(['Token' => 'abc123', 'AuthService' => 'facebook', 'UserID' => 'fb1234']);
+        $this->assertEquals($this->member->ID, $member->ID);
+    }
+
+    public function testInvalidToken() {
+        $this->givenFacebookValidatesTheTokenAs(false);
+        $this->setExpectedException('RestUserException');
+        $member = $this->sut->authenticate(['Token' => 'abc123', 'AuthService' => 'facebook', 'UserID' => 'fb1234']);
+        $this->assertNull($member);
+    }
+
+    public function testInvalidService() {
+        $this->givenFacebookValidatesTheTokenAs(true);
+        $this->setExpectedException('RestUserException');
+        $member = $this->sut->authenticate(['Token' => 'abc123', 'AuthService' => 'hackertown', 'UserID' => 'fb1234']);
+        $this->assertNull($member);
+    }
+
+    public function testInvalidUserId() {
+        $this->givenFacebookValidatesTheTokenAs(true);
+        $this->setExpectedException('RestUserException');
+        $member = $this->sut->authenticate(['Token' => 'abc123', 'AuthService' => 'facebook', 'UserID' => 'fb999']);
+        $this->assertNull($member);
+    }
+
+    public function testCanAuthenticateWithEmailAndPassword() {
+        $member = $this->sut->authenticate(['Email' => 'test@test.com', 'Password' => 'tEst1234']);
+        $this->assertEquals($this->member->ID, $member->ID);
+    }
+
+    public function testInvalidPassword() {
+        $member = $this->sut->authenticate(['Email' => 'test@test.com', 'Password' => 'wrong']);
+        $this->assertNull($member);
+    }
+
+    public function testEmpty() {
+        $member = $this->sut->authenticate([]);
+        $this->assertNull($member);
+    }
+
+    public function testCanConnectSocialAccountThroughLogin() {
+        Config::inst()->update('SocialMemberAuthenticator', 'allow_login_to_connect', true);
+        $this->identity->delete();
+        $this->givenFacebookValidatesTheTokenAs(true);
+        $this->givenFacebookReturnsProfileData(['Email' => 'test@test.com']);
+        $member = $this->sut->authenticate(['Token' => 'abc123', 'AuthService' => 'facebook', 'UserID' => 'fb1234']);
+        $this->assertEquals($this->member->ID, $member->ID);
+    }
+
+    public function testCannotConnectSocialAccountWithMismatchedEmail() {
+        Config::inst()->update('SocialMemberAuthenticator', 'allow_login_to_connect', true);
+        $this->identity->delete();
+        $this->givenFacebookValidatesTheTokenAs(true);
+        $this->givenFacebookReturnsProfileData(['Email' => 'wrong@test.com']);
+        $this->setExpectedException('RestUserException');
+        $member = $this->sut->authenticate(['Token' => 'abc123', 'AuthService' => 'facebook', 'UserID' => 'fb1234']);
+        $this->assertNull($member);
+    }
+
+    public function testCanDisableConnectingSocialAccountThroughLogin() {
+        Config::inst()->update('SocialMemberAuthenticator', 'allow_login_to_connect', false);
+        $this->identity->delete();
+        $this->givenFacebookValidatesTheTokenAs(true);
+        $this->setExpectedException('RestUserException');
+        $member = $this->sut->authenticate(['Token' => 'abc123', 'AuthService' => 'facebook', 'UserID' => 'fb1234']);
+        $this->assertNull($member);
+    }
 }

--- a/tests/unittests/validators/SessionValidatorWithSocialTest.php
+++ b/tests/unittests/validators/SessionValidatorWithSocialTest.php
@@ -6,6 +6,15 @@
  */
 class SessionValidatorWithSocialTest extends SapphireTest {
 
+    public function setUp() {
+        parent::setUp();
+        Config::inst()->update('SessionValidatorWithSocial', 'token_name', 'token');
+        Config::inst()->update('SessionValidatorWithSocial', 'auth_service_name', 'authService');
+        Config::inst()->update('SessionValidatorWithSocial', 'email_name', 'email');
+        Config::inst()->update('SessionValidatorWithSocial', 'user_id_name', 'userID');
+        Config::inst()->update('SessionValidatorWithSocial', 'password_name', 'password');
+    }
+
     public function testValidateWithEmailPassword() {
         $data = SessionValidatorWithSocial::validate(['email' => 'mail@example.com', 'password' => 'pass']);
         $this->assertTrue(array_key_exists('Email', $data));


### PR DESCRIPTION
Allows you to log in to an existing account if the emails match. The setting can be turned off by yml config.